### PR TITLE
allow copy-and-paste the multiline script

### DIFF
--- a/0a-Setup-Hadoop/GCP-Dataproc/0_setup-dataproc.sh
+++ b/0a-Setup-Hadoop/GCP-Dataproc/0_setup-dataproc.sh
@@ -1,23 +1,22 @@
-# put this script all on one line to run
 # this script uses 8 CPUs for your cluster
+
 # change the following to your settings
-# --region <your-region>
-# --zone <your-zone>
-# --project <your-project>
 
-gcloud beta dataproc clusters create demo 
-    --enable-component-gateway 
-    --region us-central1 
-    --subnet default 
-    --zone us-central1-a 
-    --master-machine-type n1-standard-4 
-    --master-boot-disk-size 500 
-    --num-workers 2 
-    --worker-machine-type n1-standard-2 
-    --worker-boot-disk-size 500 
-    --image-version 1.3-deb9 
-    --optional-components ANACONDA,HIVE_WEBHCAT,JUPYTER,DRUID,PRESTO,ZOOKEEPER 
-    --project nosql-langit
+region=us-central1
+zone=us-central1-a
+project=nosql-langit
 
-# run as one line
-gcloud beta dataproc clusters create demo --enable-component-gateway --region us-central1 --subnet default --zone us-central1-a --master-machine-type n1-standard-4 --master-boot-disk-size 500 --num-workers 2 --worker-machine-type n1-standard-2 --worker-boot-disk-size 500 --image-version 1.3-deb9 --optional-components ANACONDA,HIVE_WEBHCAT,JUPYTER,DRUID,PRESTO,ZOOKEEPER --project nosql-langit
+gcloud beta dataproc clusters create demo \
+    --enable-component-gateway \
+    --region $region \
+    --subnet default \
+    --zone $zone \
+    --master-machine-type n1-standard-4 \
+    --master-boot-disk-size 500 \
+    --num-workers 2 \
+    --worker-machine-type n1-standard-2 \
+    --worker-boot-disk-size 500 \
+    --image-version 1.3-deb9 \
+    --optional-components ANACONDA,HIVE_WEBHCAT,JUPYTER,DRUID,PRESTO,ZOOKEEPER \
+    --project $project
+    


### PR DESCRIPTION
Instead of having two versions of the script, better to make the command copy-ready.